### PR TITLE
Fix: server-side rendering styles

### DIFF
--- a/src/features/ui/lib/withStyledComponents.tsx
+++ b/src/features/ui/lib/withStyledComponents.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-document-import-in-page */
+import type * as NextDocumentTypes from 'next/document'
+import NextDocument from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+type TDocument = React.ComponentType<NextDocumentTypes.DocumentProps> & {
+  getInitialProps?: (
+    ctx: NextDocumentTypes.DocumentContext
+  ) => Promise<NextDocumentTypes.DocumentInitialProps>
+}
+
+/**
+ * A Higher-Order Component to add Server-Side Rendering capabilities
+ * to a Next.js Document (_document.tsx) component.
+ */
+const withServerSideStyles = (document: TDocument) => {
+  // Resolve getInitialProps either from the custom document, or from Next.js' default.
+  const getInitialProps =
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    document.getInitialProps ?? NextDocument.getInitialProps
+
+  // Implement getInitialProps on behalf of document.
+  document.getInitialProps = async (ctx) => {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await getInitialProps(ctx)
+      const styles = [initialProps.styles, sheet.getStyleElement()]
+
+      return { ...initialProps, styles }
+    } finally {
+      sheet.seal()
+    }
+  }
+
+  return document
+}
+
+export { withServerSideStyles }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,9 @@
-import type { DocumentContext, DocumentInitialProps } from 'next/document'
-import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+/* eslint-disable @next/next/no-page-custom-font */
+import { Html, Head, Main, NextScript } from 'next/document'
 
-type TDocument = {
-  (): JSX.Element
-  getInitialProps: (ctx: DocumentContext) => Promise<DocumentInitialProps>
-}
+import { withServerSideStyles } from '~/features/ui/lib/withStyledComponents'
 
-const Document: TDocument = () => (
+const Document = () => (
   <Html>
     <Head>
       <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -24,29 +20,4 @@ const Document: TDocument = () => (
   </Html>
 )
 
-Document.getInitialProps = async (ctx) => {
-  const sheet = new ServerStyleSheet()
-  const originalRenderPage = ctx.renderPage
-
-  try {
-    ctx.renderPage = () =>
-      originalRenderPage({
-        enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
-      })
-
-    const initialProps = await NextDocument.getInitialProps(ctx)
-    return {
-      ...initialProps,
-      styles: [
-        <>
-          {initialProps.styles}
-          {sheet.getStyleElement()}
-        </>,
-      ],
-    }
-  } finally {
-    sheet.seal()
-  }
-}
-
-export default Document
+export default withServerSideStyles(Document)

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,36 @@
-import Document, { Html, Head, Main, NextScript } from 'next/document'
+import type { DocumentContext, DocumentInitialProps } from 'next/document'
+import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
 
-class MyDocument extends Document {
+class Document extends NextDocument {
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await NextDocument.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: [
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>,
+        ],
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+
   render() {
     return (
       <Html>
@@ -25,4 +55,4 @@ class MyDocument extends Document {
   }
 }
 
-export default MyDocument
+export default Document

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,56 +2,50 @@ import type { DocumentContext, DocumentInitialProps } from 'next/document'
 import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
-class Document extends NextDocument {
-  static async getInitialProps(
-    ctx: DocumentContext
-  ): Promise<DocumentInitialProps> {
-    const sheet = new ServerStyleSheet()
-    const originalRenderPage = ctx.renderPage
+type TDocument = {
+  (): JSX.Element
+  getInitialProps: (ctx: DocumentContext) => Promise<DocumentInitialProps>
+}
 
-    try {
-      ctx.renderPage = () =>
-        originalRenderPage({
-          enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
-        })
+const Document: TDocument = () => (
+  <Html>
+    <Head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Hind:wght@400;500;600&family=Playfair+Display&display=swap"
+        rel="stylesheet"
+      />
+    </Head>
+    <body>
+      <Main />
+      <NextScript />
+    </body>
+  </Html>
+)
 
-      const initialProps = await NextDocument.getInitialProps(ctx)
-      return {
-        ...initialProps,
-        styles: [
-          <>
-            {initialProps.styles}
-            {sheet.getStyleElement()}
-          </>,
-        ],
-      }
-    } finally {
-      sheet.seal()
+Document.getInitialProps = async (ctx) => {
+  const sheet = new ServerStyleSheet()
+  const originalRenderPage = ctx.renderPage
+
+  try {
+    ctx.renderPage = () =>
+      originalRenderPage({
+        enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+      })
+
+    const initialProps = await NextDocument.getInitialProps(ctx)
+    return {
+      ...initialProps,
+      styles: [
+        <>
+          {initialProps.styles}
+          {sheet.getStyleElement()}
+        </>,
+      ],
     }
-  }
-
-  render() {
-    return (
-      <Html>
-        <Head>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin=""
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Hind:wght@400;500;600&family=Playfair+Display&display=swap"
-            rel="stylesheet"
-          />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
+  } finally {
+    sheet.seal()
   }
 }
 


### PR DESCRIPTION
This PR intends to address three things, which are separate in the ~~3~~ 2 commits:

1. [Enable server-side rendering of styles](https://github.com/strvcom/frontend-academy-2022/pull/8/commits/ae26483973f99757c089284ec7f92c6a7b87bbd8) (thanks @serhanguney for pointing the issue)
2. [Functional component at `_document.tsx`](https://github.com/strvcom/frontend-academy-2022/pull/8/commits/4a44466e57fc096101ec27233477c8e7e1a91b33) (thanks @tonycastle for questioning this)
3. ~~[Decouple styles SSR from Document logic](https://github.com/strvcom/frontend-academy-2022/pull/8/commits/7beb1249747458b9ba67195502b0834e2559418b)~~ this was moved to a separated PR.

Each of these commits have comments on the tricky parts, go check it out!