### PR TITLE
Advanced: SSR styles encapsulated in a Higher-Order Component

### DIFF
--- a/src/features/ui/lib/withStyledComponents.tsx
+++ b/src/features/ui/lib/withStyledComponents.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-document-import-in-page */
+import type * as NextDocumentTypes from 'next/document'
+import NextDocument from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+type TDocument = React.ComponentType<NextDocumentTypes.DocumentProps> & {
+  getInitialProps?: (
+    ctx: NextDocumentTypes.DocumentContext
+  ) => Promise<NextDocumentTypes.DocumentInitialProps>
+}
+
+/**
+ * A Higher-Order Component to add Server-Side Rendering capabilities
+ * to a Next.js Document (_document.tsx) component.
+ */
+const withServerSideStyles = (document: TDocument) => {
+  // Resolve getInitialProps either from the custom document, or from Next.js' default.
+  const getInitialProps =
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    document.getInitialProps ?? NextDocument.getInitialProps
+
+  // Implement getInitialProps on behalf of document.
+  document.getInitialProps = async (ctx) => {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await getInitialProps(ctx)
+      const styles = [initialProps.styles, sheet.getStyleElement()]
+
+      return { ...initialProps, styles }
+    } finally {
+      sheet.seal()
+    }
+  }
+
+  return document
+}
+
+export { withServerSideStyles }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,9 @@
-import type { DocumentContext, DocumentInitialProps } from 'next/document'
-import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+/* eslint-disable @next/next/no-page-custom-font */
+import { Html, Head, Main, NextScript } from 'next/document'
 
-type TDocument = {
-  (): JSX.Element
-  getInitialProps: (ctx: DocumentContext) => Promise<DocumentInitialProps>
-}
+import { withServerSideStyles } from '~/features/ui/lib/withStyledComponents'
 
-const Document: TDocument = () => (
+const Document = () => (
   <Html>
     <Head>
       <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -24,29 +20,4 @@ const Document: TDocument = () => (
   </Html>
 )
 
-Document.getInitialProps = async (ctx) => {
-  const sheet = new ServerStyleSheet()
-  const originalRenderPage = ctx.renderPage
-
-  try {
-    ctx.renderPage = () =>
-      originalRenderPage({
-        enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
-      })
-
-    const initialProps = await NextDocument.getInitialProps(ctx)
-    return {
-      ...initialProps,
-      styles: [
-        <>
-          {initialProps.styles}
-          {sheet.getStyleElement()}
-        </>,
-      ],
-    }
-  } finally {
-    sheet.seal()
-  }
-}
-
-export default Document
+export default withServerSideStyles(Document)


### PR DESCRIPTION
#### ⚠️ Warning
The changes contained in this PR are considered advanced, and won't be part of the final application. We'll leave it here as a reference and for learning purposes.

---

This PR intends to showcase two things:

1. Real world use case of a [HOC](https://reactjs.org/docs/higher-order-components.html) (Higher-Order Component)
2. How to use HOCs to decouple concerns

The idea here is we abstract away the whole styles SSR logic – which was copied from Next.js' official [styled-components example](https://github.com/vercel/next.js/blob/canary/examples/with-styled-components/pages/_document.tsx) – out of the `_document.tsx` page. The intention is to isolate the complexity of this styles SSR process, and make our custom Document as simple as possible, with only application concerns and not low-level SSR concerns.

Besides that, having the styles SSR encapsulated allows the Document to embark other eventual `getInitialProps` needs that might become necessary, without us having to mingle the complexity of multiple different concerns.