### PR TITLE
Advanced: Form state management step 3 – useForm

### DIFF
--- a/src/features/form/hooks/useForm.ts
+++ b/src/features/form/hooks/useForm.ts
@@ -1,0 +1,121 @@
+import type { ChangeEvent, FocusEvent, FormEvent } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+import { mapObject } from '~/utils/mapObject'
+
+import type { Validators } from '../types'
+
+type FormConfig<TFormData extends object> = {
+  initialValues?: Partial<TFormData>
+  validators?: Validators<TFormData>
+}
+
+const defaults = {
+  initialValues: {},
+  validators: {},
+}
+
+/**
+ * Execute a map of validators on values.
+ */
+const validate = <TFormData extends object>(
+  values: Partial<TFormData>,
+  validators: Validators<TFormData>
+) =>
+  mapObject(validators, (fn, field) =>
+    fn ? fn(values[field] ?? undefined) ?? null : null
+  )
+
+/**
+ * Controls login form state.
+ */
+const useForm = <TFormData extends object>(
+  config: FormConfig<TFormData> = {}
+) => {
+  type TValues = Partial<TFormData>
+
+  const {
+    initialValues = defaults.initialValues as TValues,
+    validators = defaults.validators as Validators<TFormData>,
+  } = config
+
+  const [values, setValues] = useState<TValues>(initialValues)
+  const [touched, setTouched] = useState(() => mapObject(values, () => false))
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<Error | null>(null)
+
+  // Compute errors based on validators.
+  const errors = useMemo(
+    () => validate(values, validators),
+    [values, validators]
+  )
+
+  // Compute the validity of field.
+  const invalid = useMemo(() => mapObject(errors, Boolean), [errors])
+
+  // Form is invalid when any field is invalid.
+  const isValid = useMemo(
+    () => !Object.values(invalid).some(Boolean),
+    [invalid]
+  )
+
+  /**
+   * Form submit handler constructor.
+   */
+  const handleSubmit = useCallback(
+    (handler: (values: TFormData) => Promise<void | Error>) =>
+      (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+
+        // Touch all fields uppon submission trial, so that
+        // errors might be shown to the UI.
+        setTouched((touched) => mapObject(touched, () => true))
+
+        if (isValid) {
+          setIsSubmitting(true)
+
+          const handling = handler(values as TFormData)
+
+          handling
+            .catch(setSubmitError)
+            // Ensure we reset submit state even if promise fails
+            .finally(() => setIsSubmitting(false))
+        }
+      },
+    [values, isValid]
+  )
+
+  /**
+   * Input value change handler.
+   */
+  const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+
+    // Update value.
+    setValues((values) => ({ ...values, [name]: value }))
+  }, [])
+
+  /**
+   * Input value blur handler.
+   */
+  const handleBlur = useCallback((e: FocusEvent<HTMLInputElement>) => {
+    const { name } = e.target
+
+    setTouched((touched) => ({ ...touched, [name]: true }))
+  }, [])
+
+  return {
+    values,
+    touched,
+    errors,
+    invalid,
+    isValid,
+    isSubmitting,
+    submitError,
+    handleSubmit,
+    handleChange,
+    handleBlur,
+  } as const
+}
+
+export { useForm }

--- a/src/features/form/index.ts
+++ b/src/features/form/index.ts
@@ -1,0 +1,3 @@
+export { useForm } from './hooks/useForm'
+
+export type { Validators } from './types'

--- a/src/features/form/types.ts
+++ b/src/features/form/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Form validation construct.
+ */
+type Validators<TFormData extends object> = {
+  [key in keyof TFormData]?: (
+    value: TFormData[key] | undefined
+  ) => string | void
+}
+
+export type { Validators }

--- a/src/features/login/lib/hooks/useLoginForm.ts
+++ b/src/features/login/lib/hooks/useLoginForm.ts
@@ -1,25 +1,17 @@
-import type { ChangeEvent, FocusEvent, FormEvent } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import type { Validators } from '~/features/form'
+import { useForm } from '~/features/form'
 
-import { mapObject } from '~/utils/mapObject'
-
-type TFields = 'email' | 'password'
-type TValues = { [key in TFields]: string }
-type TValidator = <TValue>(value: TValue) => void | string
-
-const initials = {
-  values: {
-    email: '',
-    password: '',
-  },
-
-  touched: {
-    email: false,
-    password: false,
-  },
+type LoginFormData = {
+  email: string
+  password: string
 }
 
-const validators: { [key in TFields]: TValidator } = {
+const initialValues: LoginFormData = {
+  email: '',
+  password: '',
+}
+
+const validators: Validators<LoginFormData> = {
   email: (value) => {
     if (typeof value !== 'string') return 'Invalid e-mail value type'
     if (!value) return 'E-mail is required'
@@ -35,84 +27,6 @@ const validators: { [key in TFields]: TValidator } = {
 /**
  * Controls login form state.
  */
-const useLoginForm = () => {
-  const [values, setValues] = useState<TValues>(initials.values)
-  const [touched, setTouched] = useState(initials.touched)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<Error | null>(null)
-
-  // Compute errors based on validators.
-  const errors = useMemo(
-    () => mapObject(validators, (fn, field) => fn(values[field]) ?? null),
-    [values]
-  )
-
-  // Compute the validity of field.
-  const invalid = useMemo(() => mapObject(errors, Boolean), [errors])
-
-  // Form is invalid when any field is invalid.
-  const isValid = useMemo(
-    () => !Object.values(invalid).some(Boolean),
-    [invalid]
-  )
-
-  /**
-   * Form submit handler constructor.
-   */
-  const handleSubmit = useCallback(
-    (handler: (values: TValues) => Promise<void | Error>) =>
-      (e: FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
-
-        // Touch all fields uppon submission trial, so that
-        // errors might be shown to the UI.
-        setTouched((touched) => mapObject(touched, () => true))
-
-        if (isValid) {
-          setIsSubmitting(true)
-
-          const handling = handler(values)
-
-          handling
-            .catch(setSubmitError)
-            // Ensure we reset submit state even if promise fails
-            .finally(() => setIsSubmitting(false))
-        }
-      },
-    [values, isValid]
-  )
-
-  /**
-   * Input value change handler.
-   */
-  const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target
-
-    // Update value.
-    setValues((values) => ({ ...values, [name]: value }))
-  }, [])
-
-  /**
-   * Input value blur handler.
-   */
-  const handleBlur = useCallback((e: FocusEvent<HTMLInputElement>) => {
-    const { name } = e.target
-
-    setTouched((touched) => ({ ...touched, [name]: true }))
-  }, [])
-
-  return {
-    values,
-    touched,
-    errors,
-    invalid,
-    isValid,
-    isSubmitting,
-    submitError,
-    handleSubmit,
-    handleChange,
-    handleBlur,
-  } as const
-}
+const useLoginForm = () => useForm({ initialValues, validators })
 
 export { useLoginForm }


### PR DESCRIPTION
#### ⚠️ Warning
The changes contained in this PR are considered advanced, and won't be part of the final application. We'll leave it here as a reference and for learning purposes.

---

We've covered how to go further on UX and state managing by adding touch states and abstracting form state managing to a separate hook. Now, what about we make this whole logic reusable to other forms?

This PR builds on top of the the previous login form state managing to cover:

1. Extract form state management from `useLoginForm` to `useForm`
2. Make form state generic, so it can be used with different form inputs ([code](https://github.com/strvcom/frontend-academy-2022/pull/12/files#diff-a732367f6e845b7fff1d77137e981981ea7d602759420a108ed68060762013a6R8-R11))
3. Update `useLoginForm` to use `useForm` ([code](https://github.com/strvcom/frontend-academy-2022/pull/12/files#diff-c47da155bb9224cc058a62d290770f5edf71ad1151024172baccaf12a2a233e0R30))

That's it! Now we could potentially use the same `useForm` hook to other forms with have :)