### PR TITLE
16.04 – Refactoring: Module Entrypoints

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,20 @@
     "react/require-default-props": [0],
     "react/sort-comp": "off",
     "import/extensions": [2, { "json": "always" }],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "order": "asc", "caseInsensitive": true },
+        "groups": [
+          ["builtin", "external"],
+          "internal",
+          "parent",
+          ["sibling", "index"]
+        ],
+        "newlines-between": "always",
+        "pathGroups": [{ "pattern": "~/**", "group": "internal" }]
+      }
+    ],
     "@typescript-eslint/no-misused-promises": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "frontend-academy-2022",
   "version": "0.1.0",
   "private": true,
+  "sideEffects": false,
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/features/api/index.ts
+++ b/src/features/api/index.ts
@@ -1,1 +1,2 @@
 export { api } from './lib/client'
+export { privateApi } from './lib/privateClient'

--- a/src/features/api/lib/client.ts
+++ b/src/features/api/lib/client.ts
@@ -1,4 +1,4 @@
-import { setAccessToken, setRefreshToken } from '~/features/auth/storage'
+import { setAccessToken, setRefreshToken } from '~/features/auth'
 
 import type {
   AfterRequestInterceptor,

--- a/src/features/api/lib/privateClient.ts
+++ b/src/features/api/lib/privateClient.ts
@@ -1,13 +1,14 @@
 import * as Sentry from '@sentry/nextjs'
 import router from 'next/router'
 
-import { api } from '~/features/api/lib/client'
+import { getAccessToken, getRefreshToken } from '~/features/auth'
+import { Routes } from '~/features/core'
+
+import { api } from './client'
 import type {
   AfterRequestInterceptor,
   BeforeRequestInterceptor,
-} from '~/features/api/lib/network-provider'
-import { getAccessToken, getRefreshToken } from '~/features/auth/storage'
-import { Routes } from '~/features/core/constants/routes'
+} from './network-provider'
 
 const appendAccessToken: BeforeRequestInterceptor = (request) => {
   const accessToken = getAccessToken()

--- a/src/features/auth/contexts/userContext.tsx
+++ b/src/features/auth/contexts/userContext.tsx
@@ -9,7 +9,7 @@ import {
   removeAccessToken,
   removePersistedUser,
   removeRefreshToken,
-} from '~/features/auth/storage'
+} from '../storage'
 
 export type UserType = {
   id: string

--- a/src/features/auth/hocs/withPrivateRoute.tsx
+++ b/src/features/auth/hocs/withPrivateRoute.tsx
@@ -2,8 +2,9 @@ import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
-import { getPersistedUser } from '~/features/auth/storage'
-import { Routes } from '~/features/core/constants/routes'
+import { Routes } from '~/features/core'
+
+import { getPersistedUser } from '../storage'
 
 export const withPrivateRoute = (WrappedComponent: NextPage): NextPage => {
   const HOCComponent: NextPage = ({ ...props }) => {

--- a/src/features/auth/hooks/useLogin.ts
+++ b/src/features/auth/hooks/useLogin.ts
@@ -1,9 +1,10 @@
 import { useMutation } from 'react-query'
 
 import { api } from '~/features/api'
-import type { UserType } from '~/features/auth/contexts/userContext'
-import { useUserContext } from '~/features/auth/contexts/userContext'
-import { setPersistedUser } from '~/features/auth/storage'
+
+import type { UserType } from '../contexts/userContext'
+import { useUserContext } from '../contexts/userContext'
+import { setPersistedUser } from '../storage'
 
 type LoginInput = {
   email: string

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,4 @@
+export * from './contexts/userContext'
+export * from './storage'
+export { useLogin } from './hooks/useLogin'
+export { withPrivateRoute } from './hocs/withPrivateRoute'

--- a/src/features/auth/storage.ts
+++ b/src/features/auth/storage.ts
@@ -1,4 +1,4 @@
-import type { UserType } from '~/features/auth/contexts/userContext'
+import type { UserType } from '~/features/auth'
 
 export const getAccessToken = () => {
   return window.localStorage.getItem('accessToken')

--- a/src/features/core/components/ErrorBoundary/index.tsx
+++ b/src/features/core/components/ErrorBoundary/index.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/nextjs'
 import type { ReactNode } from 'react'
 import { Component } from 'react'
 
-import { ServerErrorPage } from '~/features/ui/components/ErrorPage'
+import { ServerErrorPage } from '~/features/ui'
 
 type Props = {
   fallback?: ReactNode

--- a/src/features/core/index.ts
+++ b/src/features/core/index.ts
@@ -1,0 +1,3 @@
+export { Routes } from './constants/routes'
+export { HeadDefault } from './components/HeadDefault'
+export { ErrorBoundary } from './components/ErrorBoundary'

--- a/src/features/events/components/EventsList/EventsList.tsx
+++ b/src/features/events/components/EventsList/EventsList.tsx
@@ -1,21 +1,15 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
 
-import { EventItem } from '~/features/events/components/EventsList/parts/EventItem'
-import { NavigationFilter } from '~/features/events/components/EventsList/parts/NavigationFilter'
-import { NavigationView } from '~/features/events/components/EventsList/parts/NavigationView'
-import {
-  List,
-  ListItem,
-  Nav,
-} from '~/features/events/components/EventsList/styled'
-import { useEventFilterContext } from '~/features/events/contexts/event-filter'
-import {
-  useEventViewContext,
-  ViewType,
-} from '~/features/events/contexts/event-view'
-import { listBuilders } from '~/features/events/hooks/useEvents'
-import type { Event } from '~/features/events/types'
+import { useEventFilterContext } from '../../contexts/event-filter'
+import { useEventViewContext, ViewType } from '../../contexts/event-view'
+import { listBuilders } from '../../hooks/useEvents'
+import type { Event } from '../../types'
+
+import { EventItem } from './parts/EventItem'
+import { NavigationFilter } from './parts/NavigationFilter'
+import { NavigationView } from './parts/NavigationView'
+import { List, ListItem, Nav } from './styled'
 
 export type Props = {
   isLoading: boolean

--- a/src/features/events/components/EventsList/_stories/EventsList.stories.tsx
+++ b/src/features/events/components/EventsList/_stories/EventsList.stories.tsx
@@ -1,11 +1,11 @@
 import type { Story, Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
-import { EventsListComponent } from '~/features/events/components/EventsList/EventsList'
-import type { Props } from '~/features/events/components/EventsList/EventsList'
-import { EventFilterContextProvider } from '~/features/events/contexts/event-filter'
-import { EventViewContextProvider } from '~/features/events/contexts/event-view'
-import { createEvent } from '~/features/events/types.fixtures'
+import { EventFilterContextProvider } from '../../../contexts/event-filter'
+import { EventViewContextProvider } from '../../../contexts/event-view'
+import { createEvent } from '../../../types.fixtures'
+import { EventsListComponent } from '../EventsList'
+import type { Props } from '../EventsList'
 
 export default {
   title: 'Events/Events List/Component',

--- a/src/features/events/components/EventsList/parts/CreateButton/index.tsx
+++ b/src/features/events/components/EventsList/parts/CreateButton/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import type { FC } from 'react'
 
-import { Routes } from '~/features/core/constants/routes'
+import { Routes } from '~/features/core'
 
 import { PlusIcon } from './parts/PlusIcon'
 import { CreateLink } from './styled'

--- a/src/features/events/components/EventsList/parts/CreateButton/styled.ts
+++ b/src/features/events/components/EventsList/parts/CreateButton/styled.ts
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { elevations } from '~/features/ui/theme/elevations'
+import { theme } from '~/features/ui'
 
 export const CreateLink = styled.a`
-  ${elevations[900]}
+  ${theme.elevations[900]}
   display: flex;
   align-items: center;
   justify-content: center;
@@ -15,7 +14,7 @@ export const CreateLink = styled.a`
   height: 5.6rem;
   margin: 3.2rem;
   border-radius: 50%;
-  color: ${colors.text.inverted};
+  color: ${theme.colors.text.inverted};
   cursor: pointer;
-  background-color: ${colors.background.dark};
+  background-color: ${theme.colors.background.dark};
 `

--- a/src/features/events/components/EventsList/parts/EventItem/styled.ts
+++ b/src/features/events/components/EventsList/parts/EventItem/styled.ts
@@ -1,20 +1,16 @@
 import styled, { css } from 'styled-components'
 
-import { Button } from '~/features/ui/components/Button'
-import { colors } from '~/features/ui/theme/colors'
-import { elevations } from '~/features/ui/theme/elevations'
-import { mq } from '~/features/ui/theme/mq'
-import { typography } from '~/features/ui/theme/typography'
+import { Button, theme } from '~/features/ui'
 
 export const Title = styled.h3`
-  ${typography.heading.h3}
-  color: ${colors.text.base};
+  ${theme.typography.heading.h3}
+  color: ${theme.colors.text.base};
 `
 
 export const Name = styled.p``
 
 export const Description = styled.p`
-  ${typography.paragraph.normal}
+  ${theme.typography.paragraph.normal}
   margin: 3.2rem 0 4rem;
 `
 
@@ -34,10 +30,10 @@ export const EditButton = styled(Button).attrs({
 })``
 
 export const Article = styled.article<{ isRow: boolean }>`
-  ${elevations[100]}
+  ${theme.elevations[100]}
   padding: 3.2rem;
   border-radius: 2px;
-  background-color: ${colors.background.light};
+  background-color: ${theme.colors.background.light};
 
   ${(props) =>
     props.isRow &&
@@ -60,7 +56,7 @@ export const Article = styled.article<{ isRow: boolean }>`
         margin: 0;
       }
 
-      ${mq.smallOnly} {
+      ${theme.mq.smallOnly} {
         display: grid;
         grid-template-columns: 1fr auto;
 
@@ -80,7 +76,7 @@ export const Article = styled.article<{ isRow: boolean }>`
         }
       }
 
-      ${mq.medium} {
+      ${theme.mq.medium} {
         display: flex;
         align-items: baseline;
         gap: 1.5rem;
@@ -96,7 +92,7 @@ export const Article = styled.article<{ isRow: boolean }>`
         }
 
         ${Title} {
-          ${typography.heading.h4}
+          ${theme.typography.heading.h4}
           order: -2;
         }
 

--- a/src/features/events/components/EventsList/parts/NavigationFilter/styled.ts
+++ b/src/features/events/components/EventsList/parts/NavigationFilter/styled.ts
@@ -1,16 +1,13 @@
 import styled from 'styled-components'
 
-import { StyleReset } from '~/features/ui/components/StyleReset'
-import { colors } from '~/features/ui/theme/colors'
-import { mq } from '~/features/ui/theme/mq'
-import { typography } from '~/features/ui/theme/typography'
+import { StyleReset, theme } from '~/features/ui'
 
 export const List = styled.ul`
   display: none;
   padding: 0;
   list-style: none;
 
-  ${mq.medium} {
+  ${theme.mq.medium} {
     display: block;
   }
 `
@@ -18,20 +15,20 @@ export const List = styled.ul`
 export const ListItem = styled.li<{ isActive?: boolean }>`
   display: inline-block;
   margin-right: 3.2rem;
-  color: ${(props) => (props.isActive ? colors.text.base : colors.text.tabs)};
+  color: ${(props) => theme.colors.text[props.isActive ? 'base' : 'tabs']};
 
   button {
     ${StyleReset}
-    ${typography.label.small}
+    ${theme.typography.label.small}
     cursor: pointer;
   }
 `
 
 export const MobileToggleLabel = styled.label`
-  ${typography.label.small}
-  color: ${colors.text.tabs};
+  ${theme.typography.label.small}
+  color: ${theme.colors.text.tabs};
 
-  ${mq.medium} {
+  ${theme.mq.medium} {
     display: none;
   }
 
@@ -42,12 +39,12 @@ export const MobileToggleLabel = styled.label`
     border: 0.5em solid transparent;
     border-top-color: currentColor;
     border-bottom-width: 0;
-    color: ${colors.text.base};
+    color: ${theme.colors.text.base};
   }
 
   select {
     ${StyleReset}
-    color: ${colors.text.base};
+    color: ${theme.colors.text.base};
     cursor: pointer;
   }
 `

--- a/src/features/events/components/EventsList/parts/NavigationView/styled.ts
+++ b/src/features/events/components/EventsList/parts/NavigationView/styled.ts
@@ -1,13 +1,12 @@
 import styled, { css } from 'styled-components'
 
-import { StyleReset } from '~/features/ui/components/StyleReset'
-import { colors } from '~/features/ui/theme/colors'
+import { StyleReset, theme } from '~/features/ui'
 
 export const ListItem = styled.li<{ isActive: boolean }>`
   display: inline-block;
   list-style: none;
   margin-left: 0.8rem;
-  color: ${(props) => (props.isActive ? colors.text.base : colors.text.silent)};
+  color: ${(props) => theme.colors.text[props.isActive ? 'base' : 'silent']};
 
   button {
     ${StyleReset}

--- a/src/features/events/components/EventsList/styled.ts
+++ b/src/features/events/components/EventsList/styled.ts
@@ -1,8 +1,6 @@
 import styled, { css } from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { mq } from '~/features/ui/theme/mq'
-import { typography } from '~/features/ui/theme/typography'
+import { theme } from '~/features/ui'
 
 import { ViewType } from '../../contexts/event-view'
 
@@ -12,19 +10,19 @@ export const Nav = styled.nav`
   align-items: center;
   padding: 0 1.5rem;
 
-  ${mq.medium} {
+  ${theme.mq.medium} {
     padding: 0;
   }
 `
 
 export const List = styled.ul<{ view: ViewType }>`
-  ${typography.paragraph.small}
+  ${theme.typography.paragraph.small}
   display: grid;
   gap: 1.5rem;
   padding: 0;
   padding: 3rem 0 8rem;
   list-style: none;
-  color: ${colors.text.dimmed};
+  color: ${theme.colors.text.dimmed};
 
   ${(props) =>
     props.view === ViewType.GRID &&

--- a/src/features/events/hooks/useCreateEvent.ts
+++ b/src/features/events/hooks/useCreateEvent.ts
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 import { useMutation } from 'react-query'
 
-import { privateApi } from '~/features/api/lib/privateClient'
+import { privateApi } from '~/features/api'
 
 type EventInput = {
   title: string

--- a/src/features/events/hooks/useEvents.test.ts
+++ b/src/features/events/hooks/useEvents.test.ts
@@ -1,5 +1,6 @@
-import { listBuilders } from '~/features/events/hooks/useEvents'
-import type { Event } from '~/features/events/types'
+import type { Event } from '../types'
+
+import { listBuilders } from './useEvents'
 
 describe('[hooks] useEvents', () => {
   describe('listBuilders', () => {

--- a/src/features/events/index.ts
+++ b/src/features/events/index.ts
@@ -1,0 +1,12 @@
+export * from './types'
+
+export { EventsList } from './components/EventsList'
+
+export { listBuilders } from './hooks/useEvents'
+export { useCreateEvent } from './hooks/useCreateEvent'
+
+export * from './contexts/event-filter'
+export * from './contexts/event-view'
+
+export * from './pages/CreateEventPage'
+export * from './pages/DashboardPage'

--- a/src/features/events/pages/CreateEventPage/index.tsx
+++ b/src/features/events/pages/CreateEventPage/index.tsx
@@ -2,11 +2,12 @@ import { set as setTime } from 'date-fns'
 import type { NextPage } from 'next'
 import Link from 'next/link'
 
-import { withPrivateRoute } from '~/features/auth/hocs/withPrivateRoute'
-import { Routes } from '~/features/core/constants/routes'
-import { useCreateEvent } from '~/features/events/hooks/useCreateEvent'
-import { Input } from '~/features/ui/components/Input'
-import { LayoutInternal } from '~/features/ui/components/LayoutInternal'
+import { withPrivateRoute } from '~/features/auth'
+import { Routes } from '~/features/core'
+import { Input, LayoutInternal } from '~/features/ui'
+
+import { useCreateEvent } from '../../hooks/useCreateEvent'
+import { useCreateEventForm, EVENT_MIN_DATE } from '../../lib/create-event-form'
 
 import {
   CloseLink,
@@ -17,8 +18,6 @@ import {
   SubmitButton,
   Title,
 } from './styled'
-
-import { useCreateEventForm, EVENT_MIN_DATE } from '../../lib/create-event-form'
 
 const Page: NextPage = () => {
   const form = useCreateEventForm()

--- a/src/features/events/pages/CreateEventPage/styled.ts
+++ b/src/features/events/pages/CreateEventPage/styled.ts
@@ -1,10 +1,6 @@
 import styled, { keyframes } from 'styled-components'
 
-import { Button } from '~/features/ui/components/Button'
-import { Container as ContainerBase } from '~/features/ui/components/Container'
-import { colors } from '~/features/ui/theme/colors'
-import { elevations } from '~/features/ui/theme/elevations'
-import { typography } from '~/features/ui/theme/typography'
+import { Button, Container as ContainerBase, theme } from '~/features/ui'
 
 import { CloseIcon } from './parts/LogoIcon'
 
@@ -17,22 +13,22 @@ export const Container = styled(ContainerBase)`
 `
 
 export const FormWrapper = styled.div`
-  ${elevations[100]}
+  ${theme.elevations[100]}
   width: 100%;
   max-width: 48rem;
   padding: 4rem 3.2rem;
   margin: 0 auto;
   border-radius: 2px;
   text-align: center;
-  background-color: ${colors.background.light};
+  background-color: ${theme.colors.background.light};
 `
 
 export const Title = styled.h1`
-  ${typography.heading.h2}
+  ${theme.typography.heading.h2}
 `
 
 export const Description = styled.p`
-  ${typography.paragraph.large}
+  ${theme.typography.paragraph.large}
 `
 
 export const SubmitButton = styled(Button).attrs({
@@ -53,8 +49,8 @@ const closeIconAnimation = keyframes`
 `
 
 export const CloseLink = styled.a`
-  ${typography.paragraph.normal}
-  color: ${colors.text.base};
+  ${theme.typography.paragraph.normal}
+  color: ${theme.colors.text.base};
 
   ${StyledCloseIcon} {
     display: inline-block;

--- a/src/features/events/pages/DashboardPage/index.tsx
+++ b/src/features/events/pages/DashboardPage/index.tsx
@@ -1,12 +1,11 @@
 import type { NextPage } from 'next'
 
-import { EventsList } from '~/features/events/components/EventsList'
-import { Container } from '~/features/ui/components/Container'
-import { LayoutInternal } from '~/features/ui/components/LayoutInternal'
+import { Container, LayoutInternal } from '~/features/ui'
+
+import { EventsList } from '../../components/EventsList'
+import { CreateButton } from '../../components/EventsList/parts/CreateButton'
 
 import { H1, H2 } from './styled'
-
-import { CreateButton } from '../../components/EventsList/parts/CreateButton'
 
 export const DashboardPage: NextPage = () => (
   <LayoutInternal>

--- a/src/features/events/pages/DashboardPage/styled.ts
+++ b/src/features/events/pages/DashboardPage/styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { AccessibleHidden } from '~/features/ui/components/AccessibleHidden'
+import { AccessibleHidden } from '~/features/ui'
 
 export const H1 = styled.h1`
   ${AccessibleHidden}

--- a/src/features/events/types.fixtures.ts
+++ b/src/features/events/types.fixtures.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-import type { User } from '~/features/events/types'
+import type { User } from '~/features/events'
 
 export const createUser = () => ({
   id: faker.datatype.uuid(),

--- a/src/features/login/index.ts
+++ b/src/features/login/index.ts
@@ -1,0 +1,1 @@
+export * from './pages/LoginPage'

--- a/src/features/login/pages/LoginPage/index.tsx
+++ b/src/features/login/pages/LoginPage/index.tsx
@@ -2,11 +2,10 @@ import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
-import { useUserContext } from '~/features/auth/contexts/userContext'
-import { useLogin } from '~/features/auth/hooks/useLogin'
-import { Container } from '~/features/ui/components/Container'
-import { Input } from '~/features/ui/components/Input'
-import { LayoutExternal } from '~/features/ui/components/LayoutExternal'
+import { useUserContext, useLogin } from '~/features/auth'
+import { Container, Input, LayoutExternal } from '~/features/ui'
+
+import { useLoginForm } from '../../lib/login-form'
 
 import {
   Description,
@@ -15,8 +14,6 @@ import {
   Title,
   ErrorMessage,
 } from './styled'
-
-import { useLoginForm } from '../../lib/login-form'
 
 export const LoginPage: NextPage = () => {
   const router = useRouter()

--- a/src/features/login/pages/LoginPage/styled.ts
+++ b/src/features/login/pages/LoginPage/styled.ts
@@ -1,11 +1,9 @@
 import styled from 'styled-components'
 
-import { Button } from '~/features/ui/components/Button'
-import { colors } from '~/features/ui/theme/colors'
-import { typography } from '~/features/ui/theme/typography'
+import { Button, theme } from '~/features/ui'
 
 export const Title = styled.h1`
-  ${typography.heading.h2}
+  ${theme.typography.heading.h2}
 `
 
 // To not have <SubmitButton type="submit" … />, we are passing
@@ -27,11 +25,11 @@ export const FormWrapper = styled.div`
 `
 
 export const Description = styled.p`
-  ${typography.paragraph.large}
+  ${theme.typography.paragraph.large}
   margin: 0.5rem 0;
 `
 
 // We are extending the Description component and adding addional styles to it
 export const ErrorMessage = styled(Description)`
-  color: ${colors.accent.destructive};
+  color: ${theme.colors.accent.destructive};
 `

--- a/src/features/ui/components/AccountInfo/index.tsx
+++ b/src/features/ui/components/AccountInfo/index.tsx
@@ -1,5 +1,5 @@
-import type { UserType } from '~/features/auth/contexts/userContext'
-import { useUserContext } from '~/features/auth/contexts/userContext'
+import type { UserType } from '~/features/auth'
+import { useUserContext } from '~/features/auth'
 
 import { InitialsButton, User, Wrapper } from './styled'
 

--- a/src/features/ui/components/AccountInfo/styled.ts
+++ b/src/features/ui/components/AccountInfo/styled.ts
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { typography } from '~/features/ui/theme/typography'
+import * as theme from '../../theme'
 
 export const Wrapper = styled.div`
   display: flex;
@@ -13,9 +12,9 @@ export const Wrapper = styled.div`
   }
 `
 export const InitialsButton = styled.button`
-  ${typography.paragraph.small}
+  ${theme.typography.paragraph.small}
   border-radius: 50%;
-  background-color: ${colors.background.inactive};
+  background-color: ${theme.colors.background.inactive};
   font-family: 'hind', sans-serif;
   width: 40px;
   height: 40px;
@@ -23,8 +22,8 @@ export const InitialsButton = styled.button`
 `
 
 export const User = styled.span`
-  ${typography.paragraph.small}
-  color: ${colors.text.dimmed};
+  ${theme.typography.paragraph.small}
+  color: ${theme.colors.text.dimmed};
 `
 
 export const DropIcon = styled.img``

--- a/src/features/ui/components/Button/index.ts
+++ b/src/features/ui/components/Button/index.ts
@@ -1,8 +1,7 @@
 import styled, { css } from 'styled-components'
 
-import { StyleReset } from '~/features/ui/components/StyleReset'
-import { colors } from '~/features/ui/theme/colors'
-import { typography } from '~/features/ui/theme/typography'
+import * as theme from '../../theme'
+import { StyleReset } from '../StyleReset'
 
 type ButtonProps = {
   size?: 'small' | 'medium'
@@ -17,12 +16,12 @@ export const Button = styled.button<ButtonProps>`
     However, within a single file like here CSS variables can save us
     a few lines of typing and make the code easier to read.
   */
-  --text-color: ${colors.text.inverted};
-  --background-color: ${colors.background.dark};
-  --background-color-hover: ${colors.background.dark};
+  --text-color: ${theme.colors.text.inverted};
+  --background-color: ${theme.colors.background.dark};
+  --background-color-hover: ${theme.colors.background.dark};
 
   ${StyleReset}
-  ${typography.label.large}
+  ${theme.typography.label.large}
   padding: 0.8em 5.4em;
   color: var(--text-color);
   border-radius: 4px;
@@ -30,8 +29,8 @@ export const Button = styled.button<ButtonProps>`
   background-color: var(--background-color);
 
   &:disabled {
-    --text-color: ${colors.text.inactive};
-    --background-color: ${colors.background.inactive};
+    --text-color: ${theme.colors.text.inactive};
+    --background-color: ${theme.colors.background.inactive};
   }
 
   &:not(:disabled) {
@@ -46,21 +45,21 @@ export const Button = styled.button<ButtonProps>`
   ${(props) =>
     props.accent === 'primary' &&
     css`
-      --background-color: ${colors.accent.primary};
-      --background-color-hover: ${colors.accent.primaryHover};
+      --background-color: ${theme.colors.accent.primary};
+      --background-color-hover: ${theme.colors.accent.primaryHover};
     `}
 
   ${(props) =>
     props.accent === 'destructive' &&
     css`
-      --background-color: ${colors.accent.destructive};
-      --background-color-hover: ${colors.accent.destructiveHover};
+      --background-color: ${theme.colors.accent.destructive};
+      --background-color-hover: ${theme.colors.accent.destructiveHover};
     `}
 
   ${(props) =>
     props.size === 'small' &&
     css`
-      ${typography.label.medium}
+      ${theme.typography.label.medium}
       padding: 0.3em 2em 0.2em;
     `}
 `

--- a/src/features/ui/components/Container/index.ts
+++ b/src/features/ui/components/Container/index.ts
@@ -1,20 +1,22 @@
 import styled from 'styled-components'
 
-import { mq, ScreenSize } from '~/features/ui/theme/mq'
+import * as theme from '../../theme'
 
 export const Container = styled.div`
   --horizontal-spacing: 0.8rem;
 
   margin: 0 auto;
   padding: 0 var(--horizontal-spacing);
-  max-width: calc(${ScreenSize.large / 10}rem + 2 * var(--horizontal-spacing));
+  max-width: calc(
+    ${theme.ScreenSize.large / 10}rem + 2 * var(--horizontal-spacing)
+  );
   width: 100%;
 
-  ${mq.medium} {
+  ${theme.mq.medium} {
     --horizontal-spacing: 2rem;
   }
 
-  ${mq.large} {
+  ${theme.mq.large} {
     --horizontal-spacing: 4rem;
   }
 `

--- a/src/features/ui/components/ErrorPage/index.tsx
+++ b/src/features/ui/components/ErrorPage/index.tsx
@@ -1,9 +1,9 @@
 import type { NextPage } from 'next'
 import Link from 'next/link'
 
-import { Button } from '~/features/ui/components/Button'
-import { Container } from '~/features/ui/components/Container'
-import { LayoutExternal } from '~/features/ui/components/LayoutExternal'
+import { Button } from '../Button'
+import { Container } from '../Container'
+import { LayoutExternal } from '../LayoutExternal'
 
 import { HeadImage } from './parts/HeadImage'
 import { Description, Title } from './styled'

--- a/src/features/ui/components/ErrorPage/styled.ts
+++ b/src/features/ui/components/ErrorPage/styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { typography } from '~/features/ui/theme/typography'
+import { typography } from '../../theme'
 
 export const Title = styled.h1`
   ${typography.heading.h2}

--- a/src/features/ui/components/Header/index.tsx
+++ b/src/features/ui/components/Header/index.tsx
@@ -1,8 +1,9 @@
 import type { FC, ReactNode } from 'react'
 
-import { useUserContext } from '~/features/auth/contexts/userContext'
-import type { User } from '~/features/events/types'
-import { AccountInfo } from '~/features/ui/components/AccountInfo'
+import { useUserContext } from '~/features/auth'
+import type { User } from '~/features/events'
+
+import { AccountInfo } from '../AccountInfo'
 
 import { SignIn } from './parts/SignIn'
 import { StyledHeader, StyledLogo } from './styled'

--- a/src/features/ui/components/Header/parts/SignIn/styles.ts
+++ b/src/features/ui/components/Header/parts/SignIn/styles.ts
@@ -1,15 +1,14 @@
 import styled from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { typography } from '~/features/ui/theme/typography'
+import * as theme from '../../../../theme'
 
 export const Anchor = styled.a`
-  ${typography.paragraph.small}
-  color: ${colors.text.light};
+  ${theme.typography.paragraph.small}
+  color: ${theme.colors.text.light};
 
   b {
-    ${typography.label.medium}
-    color: ${colors.text.dimmed};
+    ${theme.typography.label.medium}
+    color: ${theme.colors.text.dimmed};
     font-weight: 500;
   }
 `

--- a/src/features/ui/components/Header/styled.ts
+++ b/src/features/ui/components/Header/styled.ts
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { mq } from '~/features/ui/theme/mq'
+import * as theme from '../../theme'
 
 import { Logo } from './parts/Logo'
 
@@ -16,20 +15,20 @@ export const StyledHeader = styled.header<{ isAbsolute?: boolean }>`
   padding: 2.4rem;
   z-index: 100;
 
-  ${mq.medium} {
+  ${theme.mq.medium} {
     padding: 4rem;
   }
 
   ${(props) =>
     props.isAbsolute &&
     css`
-      ${mq.medium} {
+      ${theme.mq.medium} {
         position: absolute;
         top: 0;
         left: 0;
 
         ${StyledLogo} {
-          color: ${colors.text.inverted};
+          color: ${theme.colors.text.inverted};
         }
       }
     `}

--- a/src/features/ui/components/Input/styled.ts
+++ b/src/features/ui/components/Input/styled.ts
@@ -1,7 +1,6 @@
 import styled, { css, keyframes } from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-
+import { colors } from '../../theme'
 import { StyleReset } from '../StyleReset'
 
 const padding = css`

--- a/src/features/ui/components/LayoutExternal/index.tsx
+++ b/src/features/ui/components/LayoutExternal/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, FC } from 'react'
 
-import { Header } from '~/features/ui/components/Header'
+import { Header } from '../Header'
 
 import { AsideCover } from './parts/AsideCover'
 import { Layout, Main } from './styled'

--- a/src/features/ui/components/LayoutExternal/parts/AsideCover/styled.ts
+++ b/src/features/ui/components/LayoutExternal/parts/AsideCover/styled.ts
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
-import { mq } from '~/features/ui/theme/mq'
-import { font, typography } from '~/features/ui/theme/typography'
+import { colors, mq, font, typography } from '../../../../theme'
 
 export const Aside = styled.aside`
   display: none;

--- a/src/features/ui/components/LayoutExternal/styled.ts
+++ b/src/features/ui/components/LayoutExternal/styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
-import { VerticalCenter } from '~/features/ui/components/VerticalCenter'
-import { mq } from '~/features/ui/theme/mq'
+import { mq } from '../../theme'
+import { VerticalCenter } from '../VerticalCenter'
 
 export const Layout = styled.div`
   display: flex;

--- a/src/features/ui/components/LayoutInternal/index.tsx
+++ b/src/features/ui/components/LayoutInternal/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, FC } from 'react'
 
-import { Header } from '~/features/ui/components/Header'
+import { Header } from '../Header'
 
 import { InternalGlobalStyle, Layout } from './styled'
 

--- a/src/features/ui/components/LayoutInternal/styled.ts
+++ b/src/features/ui/components/LayoutInternal/styled.ts
@@ -1,6 +1,6 @@
 import styled, { createGlobalStyle } from 'styled-components'
 
-import { colors } from '~/features/ui/theme/colors'
+import { colors } from '../../theme'
 
 export const InternalGlobalStyle = createGlobalStyle`
 body {

--- a/src/features/ui/index.ts
+++ b/src/features/ui/index.ts
@@ -1,0 +1,13 @@
+export * from './components/AccessibleHidden'
+export * from './components/AccountInfo'
+export * from './components/Button'
+export * from './components/Container'
+export * from './components/ErrorPage'
+export * from './components/Header'
+export * from './components/Input'
+export * from './components/LayoutExternal'
+export * from './components/LayoutInternal'
+export * from './components/StyleReset'
+export * from './components/VerticalCenter'
+
+export * as theme from './theme'

--- a/src/features/ui/theme/index.ts
+++ b/src/features/ui/theme/index.ts
@@ -1,0 +1,6 @@
+export { palette } from './palette'
+export { colors } from './colors'
+export { font, typography } from './typography'
+export { elevations } from './elevations'
+export { ScreenSize, mq } from './mq'
+export { GlobalStyle } from './global'

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,1 +1,1 @@
-export { NotFoundPage as default } from '~/features/ui/components/ErrorPage'
+export { NotFoundPage as default } from '~/features/ui'

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,1 +1,1 @@
-export { ServerErrorPage as default } from '~/features/ui/components/ErrorPage'
+export { ServerErrorPage as default } from '~/features/ui'

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,19 +2,20 @@ import type { AppProps } from 'next/app'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
 
-import { UserContextProvider } from '~/features/auth/contexts/userContext'
-import { ErrorBoundary } from '~/features/core/components/ErrorBoundary'
-import { HeadDefault } from '~/features/core/components/HeadDefault'
-import { EventFilterContextProvider } from '~/features/events/contexts/event-filter'
-import { EventViewContextProvider } from '~/features/events/contexts/event-view'
-import { GlobalStyle } from '~/features/ui/theme/global'
+import { UserContextProvider } from '~/features/auth'
+import { ErrorBoundary, HeadDefault } from '~/features/core'
+import {
+  EventFilterContextProvider,
+  EventViewContextProvider,
+} from '~/features/events'
+import { theme } from '~/features/ui'
 
 const queryClient = new QueryClient()
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ErrorBoundary type="next_root">
-      <GlobalStyle />
+      <theme.GlobalStyle />
       <HeadDefault />
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary type="app_root">

--- a/src/pages/events/create/index.tsx
+++ b/src/pages/events/create/index.tsx
@@ -1,1 +1,1 @@
-export { CreateEventPage as default } from '~/features/events/pages/CreateEventPage'
+export { CreateEventPage as default } from '~/features/events'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,1 @@
-export { DashboardPage as default } from '~/features/events/pages/DashboardPage'
+export { DashboardPage as default } from '~/features/events'

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,1 +1,1 @@
-export { LoginPage as default } from '~/features/login/pages/LoginPage'
+export { LoginPage as default } from '~/features/login'


### PR DESCRIPTION
When codebase grows, so does each module/feature's complexity. In a short time, you end up consuming module's assets directly, making it very hard to refactor these modules without touching other parts of the system. IDE tools can help with these refactorings a lot – for instance, by automatically changing import paths when you move some file – but better than that is to _remove_ the problem altogether.

On this PR, we establish each feature as it's own "API", exposing to other modules only what is needed to be exposed. It reduces bloated code, as imports get simpler, and improves predictability, as you from a consumer perspective won't need to navigate path of other modules to consume whatever you need from it.